### PR TITLE
Remove redundant comments

### DIFF
--- a/snippets/class.json
+++ b/snippets/class.json
@@ -4,7 +4,7 @@
         "body": [
             "class ${1:ClassName}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Class block"
@@ -14,7 +14,7 @@
         "body": [
             "class ${1:ClassName} extends ${2:MotherClass}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Class extends block"
@@ -24,7 +24,7 @@
         "body": [
             "class ${1:ClassName} implements ${2:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Class implements block"
@@ -34,7 +34,7 @@
         "body": [
             "class ${1:ClassName} extends ${2:MotherClass} implements ${3:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Class extends and implements block"
@@ -44,7 +44,7 @@
         "body": [
             "abstract class ${1:ClassName}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP abstract Class block"
@@ -54,7 +54,7 @@
         "body": [
             "abstract class ${1:ClassName} extends ${2:MotherClass}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP abstract Class extends block"
@@ -64,7 +64,7 @@
         "body": [
             "abstract class ${1:ClassName} implements ${2:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP abstract Class implements block"
@@ -74,7 +74,7 @@
         "body": [
             "abstract class ${1:ClassName} extends ${2:MotherClass} implements ${3:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP abstract Class extends and implements block"
@@ -84,7 +84,7 @@
         "body": [
             "final class ${1:ClassName}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP final Class block"
@@ -94,7 +94,7 @@
         "body": [
             "final class ${1:ClassName} extends ${2:MotherClass}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP final Class extends block"
@@ -104,7 +104,7 @@
         "body": [
             "final class ${1:ClassName} implements ${2:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP final Class implements block"
@@ -114,7 +114,7 @@
         "body": [
             "final class ${1:ClassName} extends ${2:MotherClass} implements ${3:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP final Class extends and implements block"
@@ -124,7 +124,7 @@
         "body": [
             "interface ${1:InterfaceName}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Interface block"
@@ -134,7 +134,7 @@
         "body": [
             "interface ${1:InterfaceName} extends ${2:Interfaces}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Interface extends block"
@@ -144,7 +144,7 @@
         "body": [
             "trait ${1:TraitName}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "PHP Trait block"

--- a/snippets/control.json
+++ b/snippets/control.json
@@ -3,7 +3,7 @@
         "prefix": "ifen",
         "body": [
             "if (${1:condition}):",
-            "\t${0:# code...}",
+            "\t$0",
             "endif;"
         ],
         "description": "If endif block"
@@ -12,9 +12,9 @@
         "prefix": "ifelen",
         "body": [
             "if (${1:condition}):",
-            "\t${2:# code...}",
+            "\t$2",
             "else:",
-            "\t${0:# code...}",
+            "\t$0",
             "endif;"
         ],
         "description": "If else endif block"
@@ -23,11 +23,11 @@
         "prefix": "ifelifen",
         "body": [
             "if (${1:condition}):",
-            "\t${2:# code...}",
+            "\t$2",
             "elseif (${3:condition}):",
-            "\t${4:# code...}",
+            "\t$4",
             "else:",
-            "\t${0:# code...}",
+            "\t$0",
             "endif;"
         ],
         "description": "If elseif else endif block"
@@ -36,7 +36,7 @@
         "prefix": "ifb",
         "body": [
             "if (${1:condition}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "If  block"
@@ -45,9 +45,9 @@
         "prefix": "ifel",
         "body": [
             "if (${1:condition}) {",
-            "\t${2:# code...}",
+            "\t$2",
             "} else {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "If else block"
@@ -56,11 +56,11 @@
         "prefix": "ifelif",
         "body": [
             "if (${1:condition}) {",
-            "\t${2:# code...}",
+            "\t$2",
             "} elseif (${3:condition}) {",
-            "\t${4:# code...}",
+            "\t$4",
             "} else {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "If elseif else block"
@@ -70,13 +70,13 @@
         "body": [
             "switch (\\$${1:variable}) {",
             "\tcase '${2:label}':",
-            "\t\t${3:# code...}",
+            "\t\t$3",
             "\t\tbreak;",
             "\tcase '${4:label}':",
-            "\t\t${5:# code...}",
+            "\t\t$5",
             "\t\tbreak;$6",
             "\tdefault:",
-            "\t\t${0:# code...}",
+            "\t\t$0",
             "\t\tbreak;",
             "}"
         ],
@@ -86,7 +86,7 @@
         "prefix": "cs",
         "body": [
             "case '${1:label}':",
-            "\t${2:# code...}",
+            "\t$2",
             "\tbreak;"
         ],
         "description": "Case addon block"

--- a/snippets/error.json
+++ b/snippets/error.json
@@ -3,9 +3,9 @@
         "prefix": "tryc",
         "body": [
             "try {",
-            "\t${1:# code...}",
+            "\t$1",
             "} catch (${2:\\Throwable} \\$${3:e}) {",
-            "\t${4:# code...}",
+            "\t$4",
             "}"
         ],
         "description": "Try catch block"
@@ -14,11 +14,11 @@
         "prefix": "tryf",
         "body": [
             "try {",
-            "\t${1:# code...}",
+            "\t$1",
             "} catch (${2:\\Throwable} \\$${3:e}) {",
-            "\t${4:# code...}",
+            "\t$4",
             "}$5 finally {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Try catch finally block"
@@ -27,7 +27,7 @@
         "prefix": "cat",
         "body": [
             "catch (${1:\\Throwable} \\$${2:e}) {",
-            "\t${3:# code...}",
+            "\t$3",
             "}"
         ],
         "description": "Catch block"
@@ -36,7 +36,7 @@
         "prefix": "fy",
         "body": [
             "finally {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Finally block"

--- a/snippets/function.json
+++ b/snippets/function.json
@@ -3,7 +3,7 @@
         "prefix": "fn",
         "body": [
             "function ${1:func_name}(${2:Type} \\$${3:args}): ${4:void} {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Function block"
@@ -12,7 +12,7 @@
         "prefix": "fna",
         "body": [
             "function (${1:Type} \\$${2:args}): ${3:void} {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Anonymous function block"
@@ -21,7 +21,7 @@
         "prefix": "fnu",
         "body": [
             "function (${1:Type} \\$${2:args}) use (\\$${3:vars}): ${4:void} {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Anonymous function with use block"

--- a/snippets/function.php5.json
+++ b/snippets/function.php5.json
@@ -3,7 +3,7 @@
         "prefix": "-fn",
         "body": [
             "function ${1:func_name}(\\$${2:args}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Function block PHP5"
@@ -12,7 +12,7 @@
         "prefix": "-fna",
         "body": [
             "function (\\$${1:args}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Anonymous function block PHP5"
@@ -21,7 +21,7 @@
         "prefix": "-fnu",
         "body": [
             "function (\\$${1:args}) use (\\$${2:vars}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Anonymous function with use block PHP5"

--- a/snippets/loop.json
+++ b/snippets/loop.json
@@ -3,7 +3,7 @@
         "prefix": "fore",
         "body": [
             "foreach (\\$${1:iterable} as \\$${2:item}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Foreach as $item block"
@@ -12,7 +12,7 @@
         "prefix": "forek",
         "body": [
             "foreach (\\$${1:iterable} as \\$${2:key} => \\$${3:item}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Foreach as $key => $item block"
@@ -21,7 +21,7 @@
         "prefix": "foren",
         "body": [
             "foreach (\\$${1:iterable} as \\$${2:item}):",
-            "\t${0:# code...}",
+            "\t$0",
             "endforeach;"
         ],
         "description": "Foreach end as $item block"
@@ -30,7 +30,7 @@
         "prefix": "forenk",
         "body": [
             "foreach (\\$${1:iterable} as \\$${2:key} => \\$${3:item}):",
-            "\t${0:# code...}",
+            "\t$0",
             "endforeach;"
         ],
         "description": "Foreach end as $key => $item block"
@@ -39,7 +39,7 @@
         "prefix": "forl",
         "body": [
             "for (\\$${1:i} = ${2:0}; \\$${1:i} < \\$${3:limit}; \\$${1:i}++) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "For loop"
@@ -48,7 +48,7 @@
         "prefix": "forlen",
         "body": [
             "for (\\$${1:i} = ${2:0}; \\$${1:i} < \\$${3:limit}; \\$${1:i}++):",
-            "\t${0:# code...}",
+            "\t$0",
             "endfor;"
         ],
         "description": "For end loop"
@@ -57,7 +57,7 @@
         "prefix": "wl",
         "body": [
             "while (\\$${1:variable} ${2:<=} \\$${3:limit}) {",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "While loop"
@@ -66,7 +66,7 @@
         "prefix": "wlen",
         "body": [
             "while (\\$${1:variable} ${2:<=} \\$${3:limit}):",
-            "\t${0:# code...}",
+            "\t$0",
             "endwhile;"
         ],
         "description": "While end loop"
@@ -75,7 +75,7 @@
         "prefix": "dowl",
         "body": [
             "do {",
-            "\t${0:# code...}",
+            "\t$0",
             "} while (\\$${1:variable} ${2:<=} \\$${3:limit});"
         ],
         "description": "Do while loop"

--- a/snippets/method.json
+++ b/snippets/method.json
@@ -4,7 +4,7 @@
         "body": [
             "public function __construct(${1:Type} \\$${2:args})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Class public constructor block"
@@ -14,7 +14,7 @@
         "body": [
             "private function __construct(${1:Type} \\$${2:args})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Class private constructor block"
@@ -24,7 +24,7 @@
         "body": [
             "protected function __construct(${1:Type} \\$${2:args})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Class protected constructor block"
@@ -34,7 +34,7 @@
         "body": [
             "private function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Private method block"
@@ -44,7 +44,7 @@
         "body": [
             "private static function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Private static method block"
@@ -54,7 +54,7 @@
         "body": [
             "final private function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final private method block"
@@ -64,7 +64,7 @@
         "body": [
             "final private static function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final private static method block"
@@ -74,7 +74,7 @@
         "body": [
             "protected function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Protected method block"
@@ -84,7 +84,7 @@
         "body": [
             "protected static function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Protected static method block"
@@ -94,7 +94,7 @@
         "body": [
             "final protected function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final protected method block"
@@ -104,7 +104,7 @@
         "body": [
             "final protected static function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final protected static method block"
@@ -128,7 +128,7 @@
         "body": [
             "public function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Public method block"
@@ -138,7 +138,7 @@
         "body": [
             "public static function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Public static method block"
@@ -148,7 +148,7 @@
         "body": [
             "final public function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final public method block"
@@ -158,7 +158,7 @@
         "body": [
             "final public static function ${1:methodName}(${2:Type} \\$${3:args}): ${4:void}",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final public static method block"

--- a/snippets/method.php5.json
+++ b/snippets/method.php5.json
@@ -4,7 +4,7 @@
         "body": [
             "private function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Private method block PHP5"
@@ -14,7 +14,7 @@
         "body": [
             "private static function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Private static method block PHP5"
@@ -24,7 +24,7 @@
         "body": [
             "final private function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final private method block PHP5"
@@ -34,7 +34,7 @@
         "body": [
             "final private static function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final private static method block PHP5"
@@ -44,7 +44,7 @@
         "body": [
             "protected function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Protected method block PHP5"
@@ -54,7 +54,7 @@
         "body": [
             "protected static function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Protected static method block PHP5"
@@ -64,7 +64,7 @@
         "body": [
             "final protected function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final protected method block PHP5"
@@ -74,7 +74,7 @@
         "body": [
             "final protected static function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final protected static method block PHP5"
@@ -98,7 +98,7 @@
         "body": [
             "public function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Public method block PHP5"
@@ -108,7 +108,7 @@
         "body": [
             "public static function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Public static method block PHP5"
@@ -118,7 +118,7 @@
         "body": [
             "final public function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final public method block PHP5"
@@ -128,7 +128,7 @@
         "body": [
             "final public static function ${1:methodName}(${2:parameters})",
             "{",
-            "\t${0:# code...}",
+            "\t$0",
             "}"
         ],
         "description": "Final public static method block PHP5"

--- a/snippets/tag.json
+++ b/snippets/tag.json
@@ -2,7 +2,7 @@
     "PHP tags": {
         "prefix": "php",
         "body": [
-            "<?php $0?>"
+            "<?php $0 ?>"
         ],
         "description": "PHP open tag"
     },


### PR DESCRIPTION
`\t${0:# code...}",`
They are ok when you're keeping snippet's steps, but once you press Escape (or any key that cancels tabstops), these comments are remain in the code, and you have to manually remove them. Annoying -_-